### PR TITLE
Add GitLeaks Scanning to PRs

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,23 @@
+name: GitLeaks Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  GitLeaks:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: GitLeaks Scan
+        run: |
+          if [ -f .github/gitleaks.toml ]
+          then
+            ARGS="--additional-config .github/gitleaks.toml"
+          else
+            ARGS=""
+          fi
+          docker run -v "$(pwd):/$(basename $(pwd))" zricethezav/gitleaks:latest --path="/$(basename $(pwd))" --verbose --no-git $(echo $ARGS)
+


### PR DESCRIPTION
# Automated Scanning of Pull Requests for API Keys

As part of the ongoing effort to secure TuneIn's GitHub repos to prevent another occurrence similar to what happened with [CodeCov](https://www.zdnet.com/article/codecov-breach-impacted-hundreds-of-customer-networks/), we will be implementing a scan that runs on PRs opened to the primary branch of each repo. The code for the PR will be checked out and the cli tool [`gitleaks`](https://github.com/zricethezav/gitleaks) will be run against it. If there are findings, the failed check will show on the "Conversation" tab of the PR. In order for all checks against an open PR to succeed, the PR **must not** contain sensitive keys.

## What do I do if my PR check fails?

If you have mistakenly checked in a secret to git as part of your PR, you should remove it promptly.

* Git reset to the commit prior to the secret being added to source control
* Edit the file(s) containing secrets to remove them
* Author a new commit containing the fix as well as your other work
* Force-push the new commit history to git

The force push is essential to ensure that the secret is not only removed from the most recent commit but from the history as well. After performing this sequence of steps, the automated scan on your PR will pass.

## Help! The scan says I have checked in secrets but it's a false positive.

Every repo's scanning rules are customizable. Refer to the [Custom Rules](#custom-rules) section below for en explanation of the syntax to add the path containing a false positive to the `allowlist`. Exercise caution when findings are added to the `allowlist` to ensure that the findings are not genuine. Entries in the `allowlist` will not appear on subsequent scans.

## What about tokens that my team regularly works with that are not picked up by [the default scan rules](https://github.com/zricethezav/gitleaks/blob/master/config/default.go)?

You can add [custom rules to your config](#custom-rules) that meet the needs of your team. Rules are picked up by scanning files with a list of regular expressions. Write a regex for the types of tokens that your app interacts with and add it to your [custom config file](#custom-rules).

## Custom Rules

Custom rules for your repo should live in the file `.github/gitleaks.toml`. See examples below for some available customizations or, refer to [the documentation for `gitleaks`](https://github.com/zricethezav/gitleaks/blob/master/README.md#configuration) for more complete examples.

### Adding a path to the `allowlist`

```toml
[allowlist]
  files = [ '''file-regex-a''', '''file-regex-b''']
```

### Adding a custom rule

```toml
[[rules]]
  description = "NPM Token"
  regex = '''(npm|NPM)(.+)\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b'''
  tags = ["key", "NPM"]
```

## Alternatives to Secrets in Git

If your team is already using a strategy to prevent checking secrets into source control, continue to utilize that going forward. If you are in search of a solution, the strategies below are being utilized in teams at TuneIn already. Reach out to [#devops](https://tunein.slack.com/archives/C1ZBLSHB2) if you need assistance with getting one of these solutions in place.

* [Mozilla Sops](https://github.com/mozilla/sops)
* [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/)
* [Kubernetes Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets)